### PR TITLE
Allow compiling on newer rust nightlies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 target
+.DS_STORE

--- a/crates/vtables/src/lib.rs
+++ b/crates/vtables/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(pointer_is_aligned)]
 #![feature(strict_provenance)]
+#![feature(exposed_provenance)]
 use std::{
     alloc::Layout,
     any::{Any, TypeId},

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,3 +1,4 @@
+#![allow(invalid_reference_casting)]
 use std::{
     collections::{BTreeMap, HashMap},
     sync::{


### PR DESCRIPTION
Newer rust nightlies error when building some of these features without these attributes.

Also blocks .DS_Store from being pushed to the repo.