### PR TITLE
fighter/weapon callback

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -1,7 +1,8 @@
 use locks::RwLock;
 use skyline::hooks::InlineCtx;
 use smash::lib::L2CValue;
-use smashline::{Hash40, L2CFighterBase, StatusLine, Variadic};
+use smash::app::BattleObject;
+use smashline::{BattleObjectCategory, Hash40, L2CFighterBase, StatusLine, Variadic};
 
 pub type Callback = extern "C" fn(&mut L2CFighterBase);
 pub type Callback1 = extern "C" fn(&mut L2CFighterBase, &mut L2CValue);
@@ -199,7 +200,17 @@ unsafe fn call_line_status_hook(
         if let StatusCallbackFunction::Main(callback_fn) = callback.function {
             if let Some(hash) = callback.hash {
                 if agent != hash {
-                    continue;
+                    let object: &mut BattleObject = unsafe {std::mem::transmute(fighter.battle_object)};
+                    if let Some(category) = BattleObjectCategory::from_battle_object_id(object.battle_object_id) {
+                        match category {
+                            BattleObjectCategory::Fighter => if hash != Hash40::new("fighter") { continue; },
+                            BattleObjectCategory::Weapon => if hash != Hash40::new("weapon") { continue; },
+                            _ => { continue; }
+                        }
+                    }
+                    else {
+                        continue;
+                    }
                 }
             }
 

--- a/src/state_callback.rs
+++ b/src/state_callback.rs
@@ -1,6 +1,7 @@
 use locks::RwLock;
 use skyline::hooks::InlineCtx;
-use smashline::{Hash40, L2CFighterBase, ObjectEvent};
+use smash::app::BattleObject;
+use smashline::{BattleObjectCategory, Hash40, L2CFighterBase, ObjectEvent};
 
 pub type StateCallbackFunction = unsafe extern "C" fn(&mut L2CFighterBase);
 
@@ -19,7 +20,18 @@ fn call_state_callback(agent: &mut L2CFighterBase, event: ObjectEvent) {
     for callback in callbacks.iter().filter(|cb| cb.event == event) {
         if let Some(required) = callback.agent {
             if hash != required {
-                continue;
+                let object: &mut BattleObject = unsafe {std::mem::transmute(agent.battle_object)};
+                if let Some(category) = BattleObjectCategory::from_battle_object_id(object.battle_object_id) {
+                    println!("category: {:#?}", category);
+                    match category {
+                        BattleObjectCategory::Fighter => if required != Hash40::new("fighter") { continue; },
+                        BattleObjectCategory::Weapon => if required != Hash40::new("weapon") { continue; },
+                        _ => { continue; }
+                    }
+                }
+                else {
+                    continue;
+                }
             }
         }
 


### PR DESCRIPTION
Allows "fighter" and "weapon" to be checked during status and line callbacks.