### PR TITLE
Add ACMD Script Priority

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.2.6"
+version = "1.3.0"
 authors = ["blujay <the.blu.dev@gmail.com>"]
 description = "An object script replacement engine for Super Smash Bros. Ultimate"
 edition = "2021"

--- a/crates/smashline/src/builder.rs
+++ b/crates/smashline/src/builder.rs
@@ -1,6 +1,9 @@
 use crate::{AsHash40, ObjectEvent, Priority, StatusLine};
 
 pub type AcmdFunction = unsafe extern "C" fn(&mut crate::L2CAgentBase);
+
+pub unsafe extern "C" fn acmd_stub(_agent: &mut crate::L2CAgentBase) {}
+
 pub type StateFunction<T> = unsafe extern "C" fn(&mut T);
 
 mod __sealed {

--- a/crates/smashline/src/builder.rs
+++ b/crates/smashline/src/builder.rs
@@ -68,6 +68,7 @@ struct AcmdScript {
     category: crate::Acmd,
     replaces: crate::Hash40,
     function: AcmdFunction,
+    priority: Priority
 }
 
 struct LineCallback {
@@ -105,7 +106,7 @@ impl Agent {
         }
     }
 
-    pub fn acmd(&mut self, name: &str, function: AcmdFunction) -> &mut Self {
+    pub fn acmd(&mut self, name: &str, function: AcmdFunction, priority: Priority) -> &mut Self {
         let category = if name.starts_with("game") {
             Some(crate::Acmd::Game)
         }
@@ -126,6 +127,7 @@ impl Agent {
                 category: category.unwrap(),
                 replaces: name.as_hash40(),
                 function,
+                priority,
             });
         }
         else {
@@ -134,39 +136,43 @@ impl Agent {
         self
     }
 
-    pub fn game_acmd(&mut self, name: impl AsHash40, function: AcmdFunction) -> &mut Self {
+    pub fn game_acmd(&mut self, name: impl AsHash40, function: AcmdFunction, priority: Priority) -> &mut Self {
         self.acmd.push(AcmdScript {
             category: crate::Acmd::Game,
             replaces: name.as_hash40(),
             function,
+            priority
         });
         self
     }
 
-    pub fn effect_acmd(&mut self, name: impl AsHash40, function: AcmdFunction) -> &mut Self {
+    pub fn effect_acmd(&mut self, name: impl AsHash40, function: AcmdFunction, priority: Priority) -> &mut Self {
         self.acmd.push(AcmdScript {
             category: crate::Acmd::Effect,
             replaces: name.as_hash40(),
             function,
+            priority
         });
         self
     }
 
-    pub fn sound_acmd(&mut self, name: impl AsHash40, function: AcmdFunction) -> &mut Self {
+    pub fn sound_acmd(&mut self, name: impl AsHash40, function: AcmdFunction, priority: Priority) -> &mut Self {
         self.acmd.push(AcmdScript {
             category: crate::Acmd::Sound,
             replaces: name.as_hash40(),
             function,
+            priority
         });
 
         self
     }
 
-    pub fn expression_acmd(&mut self, name: impl AsHash40, function: AcmdFunction) -> &mut Self {
+    pub fn expression_acmd(&mut self, name: impl AsHash40, function: AcmdFunction, priority: Priority) -> &mut Self {
         self.acmd.push(AcmdScript {
             category: crate::Acmd::Expression,
             replaces: name.as_hash40(),
             function,
+            priority
         });
 
         self
@@ -242,7 +248,7 @@ impl Agent {
                 self.kind_hash,
                 acmd.replaces,
                 acmd.category,
-                Priority::Default,
+                acmd.priority,
                 acmd.function,
             );
         }

--- a/crates/smashline/src/lib.rs
+++ b/crates/smashline/src/lib.rs
@@ -30,11 +30,21 @@ pub use smash_rs::{
 pub use locks;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, PartialOrd)]
 pub enum Priority {
-    Default,
     Low,
+    Default,
     High,
+}
+
+impl std::fmt::Display for Priority {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+       match self {
+           Priority::Low => write!(f, "Low Priority"),
+           Priority::Default => write!(f, "Default Priority"),
+           Priority::High => write!(f, "High Priority"),
+       }
+    }
 }
 
 #[repr(C)]
@@ -44,6 +54,17 @@ pub enum Acmd {
     Effect,
     Sound,
     Expression,
+}
+
+impl std::fmt::Display for Acmd {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+       match self {
+           Acmd::Game => write!(f, "Category Game"),
+           Acmd::Effect => write!(f, "Category Effect"),
+           Acmd::Sound => write!(f, "Category Sound"),
+           Acmd::Expression => write!(f, "Category Expression"),
+       }
+    }
 }
 
 impl PartialEq<acmd_engine::asset::Category> for Acmd {


### PR DESCRIPTION
# Changelog

Adds ACMD Script Priority, a feature that was in Smashline 1.

THIS IS A BREAKING CHANGE. It's possible that the 1.3.0 libsmashline_plugin.nro will work with projects compiled on 1.2.6 and vice versa, but make sure to update smashline via cargo skyline update, as well as updating libsmashline_plugin.nro.

Also adds easier stubbing of acmd scripts by simply calling `acmd_stub` as the function.