### PR TITLE
Transplant Bugfix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.2.6"
+version = "1.2.7"
 authors = ["blujay <the.blu.dev@gmail.com>"]
 description = "An object script replacement engine for Super Smash Bros. Ultimate"
 edition = "2021"

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -49,7 +49,7 @@ unsafe fn load_fighter_effects(ctx: &InlineCtx) {
 
         let _result = load_effects(
             *ctx.registers[0].x.as_ref() as _,
-            *ctx.registers[1].x.as_ref() as u32 + num_transplants,
+            *ctx.registers[1].x.as_ref() as u32 + num_transplants * 2000,
             &index,
         );
 


### PR DESCRIPTION
# Changelog

Fixes an issue with transplanted effects where the character ID after the one with the transplanted effects will no longer have any effects show.

Eg. Steve has a transplanted effect. If Steve and Sephiroth are in the same match, Sephiroth's effects will no longer exist.