### PR TITLE
Clone_weapon now returns an ID

### DIFF
--- a/crates/smashline/src/lib.rs
+++ b/crates/smashline/src/lib.rs
@@ -343,7 +343,7 @@ decl_imports! {
         new_owner: StringFFI,
         new_name: StringFFI,
         use_original_code: bool
-    );
+    ) -> i32;
 
     fn smashline_add_param_object(
         fighter_name: StringFFI,
@@ -376,14 +376,14 @@ pub fn clone_weapon(
     new_owner: impl Into<String>,
     new_name: impl Into<String>,
     use_original_code: bool,
-) {
+) -> i32 {
     smashline_clone_weapon(
         StringFFI::from_str(original_owner),
         StringFFI::from_str(original_name),
         StringFFI::from_str(new_owner),
         StringFFI::from_str(new_name),
         use_original_code,
-    );
+    )
 }
 
 pub fn add_param_object(fighter: impl Into<String>, object: impl Into<String>) {

--- a/src/api.rs
+++ b/src/api.rs
@@ -247,6 +247,18 @@ pub extern "C" fn smashline_clone_weapon(
         return id as i32;
     }
 
+    for agents in new_agents.values() {
+        if let Some(agent) = agents.iter().find(|agent| 
+            agent.owner_name == new_owner && agent.new_name == new_name
+        ) {
+            let owner = LOWERCASE_FIGHTER_NAMES.get(agent.old_owner_id as usize).unwrap();
+            panic!(
+                "Weapon with the name '{}_{}' has already been cloned, but using '{}_{}' instead of '{}_{}'", 
+                new_owner, new_name, owner, agent.old_name, original_owner, original_name
+            );
+        }
+    }
+
     new_agents
         .entry(original_name_id as i32)
         .or_default()


### PR DESCRIPTION
### clone_weapon

- Now returns an i32, which is the cloned article's ID
  - `FIGHTER_X_GENERATE_ARTICLE_A = 0x2 + clone_weapon(...);`
 `0x2` is the number of articles your fighter originally has.
- Panics when trying to clone a new weapon, and that agent already exists
  - Doing `clone_weapon(mario, x, captain, apple)` and `clone_weapon(link, y, captain, apple)` panics
  - But if someone did this for some reason, with the dev plugin, it wouldn't panic, and returns the ID for `link_y`(`captain_banana`):
`clone_weapon(mario, x, captain, apple)`
`clone_weapon(link, y, captain, banana)`, and then later changed it to `clone_weapon(link, y, captain, apple)`