### PR TITLE
Article Updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.3.0"
+version = "1.4.0"
 authors = ["blujay <the.blu.dev@gmail.com>"]
 description = "An object script replacement engine for Super Smash Bros. Ultimate"
 edition = "2021"

--- a/crates/smashline/src/lib.rs
+++ b/crates/smashline/src/lib.rs
@@ -339,7 +339,7 @@ decl_imports! {
 
     fn smashline_clone_weapon(
         original_owner: StringFFI,
-        original_name: StringFFI,
+        original_article_id: i32,
         new_owner: StringFFI,
         new_name: StringFFI,
         use_original_code: bool
@@ -377,14 +377,14 @@ pub fn original_status<L: StatusLineMarker, T>(
 
 pub fn clone_weapon(
     original_owner: impl Into<String>,
-    original_name: impl Into<String>,
+    original_article_id: i32,
     new_owner: impl Into<String>,
     new_name: impl Into<String>,
     use_original_code: bool,
 ) {
     smashline_clone_weapon(
         StringFFI::from_str(original_owner),
-        StringFFI::from_str(original_name),
+        original_article_id,
         StringFFI::from_str(new_owner),
         StringFFI::from_str(new_name),
         use_original_code,

--- a/crates/smashline/src/lib.rs
+++ b/crates/smashline/src/lib.rs
@@ -345,6 +345,11 @@ decl_imports! {
         use_original_code: bool
     );
 
+    fn smashline_update_weapon_count(
+        article_id: i32,
+        new_count: i32
+    );
+
     fn smashline_add_param_object(
         fighter_name: StringFFI,
         object: StringFFI
@@ -383,6 +388,16 @@ pub fn clone_weapon(
         StringFFI::from_str(new_owner),
         StringFFI::from_str(new_name),
         use_original_code,
+    );
+}
+
+pub fn update_weapon_count(
+    article_id: i32,
+    new_count: i32
+) {
+    smashline_update_weapon_count(
+        article_id,
+        new_count
     );
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -208,13 +208,12 @@ pub extern "C" fn smashline_reload_script(
 #[no_mangle]
 pub extern "C" fn smashline_clone_weapon(
     original_owner: StringFFI,
-    original_name: StringFFI,
+    original_article_id: i32,
     new_owner: StringFFI,
     new_name: StringFFI,
     use_original_code: bool,
 ) {
     let original_owner = original_owner.as_str().unwrap().to_string();
-    let original_name = original_name.as_str().unwrap().to_string();
     let new_owner = new_owner.as_str().unwrap().to_string();
     let new_name = new_name.as_str().unwrap().to_string();
 
@@ -223,10 +222,12 @@ pub extern "C" fn smashline_clone_weapon(
         .position(|name| name == original_owner)
         .unwrap();
 
-    let original_name_id = LOWERCASE_WEAPON_NAMES
-        .iter()
-        .position(|name| name == original_name)
-        .unwrap();
+    // let original_name_id = LOWERCASE_WEAPON_NAMES
+    //     .iter()
+    //     .position(|name| name == original_name)
+    //     .unwrap();
+
+    let original_name = LOWERCASE_WEAPON_NAMES.get(original_article_id as usize).unwrap();
 
     let new_owner_id = LOWERCASE_FIGHTER_NAMES
         .iter()
@@ -235,7 +236,7 @@ pub extern "C" fn smashline_clone_weapon(
 
     crate::cloning::weapons::NEW_AGENTS
         .write()
-        .entry(original_name_id as i32)
+        .entry(original_article_id as i32)
         .or_default()
         .push(NewAgent {
             old_owner_id: original_owner_id as i32,
@@ -244,7 +245,7 @@ pub extern "C" fn smashline_clone_weapon(
             new_name_ffi: format!("{new_name}\0"),
             owner_name: new_owner,
             new_name,
-            old_name: original_name,
+            old_name: original_name.to_string(),
             use_original_code,
         });
 
@@ -254,7 +255,7 @@ pub extern "C" fn smashline_clone_weapon(
         .or_default()
         .push(NewArticle {
             original_owner: original_owner_id as i32,
-            weapon_id: original_name_id as i32,
+            weapon_id: original_article_id,
         });
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -14,7 +14,7 @@ use crate::{
     cloning::weapons::{NewAgent, NewArticle},
     create_agent::{
         AcmdScript, StatusScript, StatusScriptFunction, LOWERCASE_FIGHTER_NAMES,
-        LOWERCASE_WEAPON_NAMES,
+        LOWERCASE_WEAPON_NAMES
     },
     state_callback::{StateCallback, StateCallbackFunction},
 };
@@ -256,4 +256,15 @@ pub extern "C" fn smashline_clone_weapon(
             original_owner: original_owner_id as i32,
             weapon_id: original_name_id as i32,
         });
+}
+
+#[no_mangle]
+pub extern "C" fn smashline_update_weapon_count(
+    article_id: i32,
+    new_count: i32
+) {
+    *crate::cloning::weapons::WEAPON_COUNT_UPDATE
+        .write()
+        .entry(article_id)
+        .or_default() = new_count;
 }

--- a/src/state_callback.rs
+++ b/src/state_callback.rs
@@ -40,11 +40,12 @@ fn call_state_callback(agent: &mut L2CFighterBase, event: ObjectEvent) {
     }
 }
 
+pub static mut CURRENT_AGENT_BASE : u64 = 0;
+
 #[skyline::hook(offset = 0x48ad04, inline)]
 unsafe fn lua_module_start_lua2cpp(ctx: &InlineCtx) {
     let module = *ctx.registers[19].x.as_ref() as *const u64;
-    let agent = std::mem::transmute(*module.add(0x1d8 / 8));
-    call_state_callback(agent, ObjectEvent::Start);
+    CURRENT_AGENT_BASE = *module.add(0x1d8 / 8);
 }
 
 #[skyline::hook(offset = 0x48ada0)]
@@ -65,11 +66,19 @@ unsafe fn lua_module_finalize_lua2cpp(ctx: &InlineCtx) {
     call_state_callback(agent, ObjectEvent::Finalize);
 }
 
+#[skyline::hook(offset = 0x3afdf4, inline)]
+unsafe fn start_module_accessor_end(ctx: &InlineCtx) {
+    let agent = std::mem::transmute(CURRENT_AGENT_BASE);
+    call_state_callback(agent, ObjectEvent::Start);
+}
+
 pub fn install_state_callback_hooks() {
     skyline::install_hooks!(
         lua_module_start_lua2cpp,
         lua_module_end,
         lua_module_initialize_lua2cpp,
-        lua_module_finalize_lua2cpp
+        lua_module_finalize_lua2cpp,
+
+        start_module_accessor_end,
     );
 }


### PR DESCRIPTION
# Changelog

## On_Start

On_Start now runs at the end of the BattleObjectModuleAccessor::start function instead of specifically while starting LuaModule. This allows WorkModule to be started, letting you set flags, ints, and floats in an on_start.

## Update Weapon Count

Allows you to update how many of a specific article the fighter is allowed to have.

```rs
smashline::update_weapon_count(*WEAPON_KIND_MARIO_FIREBALL, 1);
// This would change how many fireballs Mario is allowed to just a single fireball.
```

## Weapon Cloning Bugfix
Currently, the way that weapon cloning works is such:
```
smashline::clone_weapon(
    /* original owner */,
    original article name,
    /* new owner */,
    /* new article name */,
    /* use original code */
);
```
`original article name` would be passed into a StaticArrayAccessor, which then spits out an article index.
However, this doesn't account for articles with the same name, such as Mario and Luigi's Fireball. If you tried cloning Luigi's Fireball, for example, the game would assign the new article *Mario's* fireball weapon ID, which would cause the game to crash.

Weapon cloning will now work by directly passing in the article's ID:
```
smashline::clone_weapon(
    /* original owner */,
    *WEAPON_KIND_OWNER_ARTICLENAME,
    /* new owner */,
    /* new article name */,
    /* use original code */
);