### PR TITLE
Copy Ability Articles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.4.2"
+version = "1.5.0"
 authors = ["blujay <the.blu.dev@gmail.com>"]
 description = "An object script replacement engine for Super Smash Bros. Ultimate"
 edition = "2021"

--- a/src/cloning/weapons.rs
+++ b/src/cloning/weapons.rs
@@ -238,9 +238,52 @@ decl_hooks! {
     status_script_weapon_name(8, 3, 0x33ac1d4)
 }
 
+macro_rules! decl_hooks_kirby {
+    ($install_fn:ident => $func:expr; $($name:ident($str:expr, $knd:expr, $offset:expr));*) => {
+        $(
+            #[skyline::hook(offset = $offset, inline)]
+            unsafe fn $name(ctx: &mut InlineCtx) {
+                $func(ctx, $str, $knd);
+            }
+        )*
+
+        fn $install_fn() {
+            $(
+                let _ = skyline::patching::Patch::in_text($offset).nop();
+            )*
+            skyline::install_hooks!(
+                $(
+                    $name,
+                )*
+            );
+        }
+    }
+}
+
+decl_hooks_kirby! {
+    install_kirby_copy_hooks => kirby_get_copy_articles;
+    copy_setup_hook(23, 20, 0xba14f4);
+    copy_hook_1(9, 9, 0xba3e0c);
+    copy_hook_2(9, 9, 0xba400c);
+    copy_hook_3(9, 9, 0xba405c);
+    copy_hook_4(12, 20, 0xba5434)
+}
+
+unsafe fn kirby_get_copy_articles(ctx: &mut InlineCtx, store_reg: usize, kind_reg: usize) {
+    let kind = *ctx.registers[kind_reg].x.as_ref() as i32;
+    let fighter_data = get_static_fighter_data(kind);
+    let article_data = (*fighter_data).static_article_info;
+    *ctx.registers[store_reg].x.as_mut() = article_data as *const u64 as u64;
+}
+
 pub fn install() {
     install_weapon_name_hooks();
     install_weapon_owner_hooks();
     install_weapon_owner_name_hooks();
-    skyline::install_hooks!(get_static_fighter_data);
+
+    skyline::install_hooks!(
+        get_static_fighter_data
+    );
+
+    install_kirby_copy_hooks();
 }


### PR DESCRIPTION
Allows Kirby to use any article from the copied fighter.

# IMPORTANT INFORMATION

- Most articles will NOT function completely as intended due to Kirby not having access to all of the copied fighters' params, as shown below.
- The only articles this was tested with are Terry's Power Geyser and Palutena's Explosive Flame.
- This **DOES NOT** allow Kirby to gain cloned articles to prevent a similar crash as Villager/Isabelle trying to pocket a cloned article.

https://github.com/user-attachments/assets/17efce9b-be50-4945-87ae-472548d19ab7
