### PR TITLE
Copy Ability Whitelist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.5.0"
+version = "1.5.1"
 authors = ["blujay <the.blu.dev@gmail.com>"]
 description = "An object script replacement engine for Super Smash Bros. Ultimate"
 edition = "2021"

--- a/crates/smashline/src/lib.rs
+++ b/crates/smashline/src/lib.rs
@@ -354,6 +354,11 @@ decl_imports! {
         fighter_name: StringFFI,
         object: StringFFI
     );
+
+    fn smashline_whitelist_kirby_copy_article(
+        fighter_id: i32,
+        article_id: i32
+    );
 }
 
 pub fn original_acmd(agent: &mut L2CAgentBase, name: Hash40) -> AcmdFunction {
@@ -403,6 +408,10 @@ pub fn update_weapon_count(
 
 pub fn add_param_object(fighter: impl Into<String>, object: impl Into<String>) {
     smashline_add_param_object(StringFFI::from_str(fighter), StringFFI::from_str(object));
+}
+
+pub fn whitelist_kirby_copy_article(fighter_id: i32, article_id: i32) {
+    smashline_whitelist_kirby_copy_article(fighter_id, article_id);
 }
 
 pub mod api {

--- a/src/api.rs
+++ b/src/api.rs
@@ -293,3 +293,22 @@ pub extern "C" fn smashline_update_weapon_count(
         .entry(article_id)
         .or_default() = new_count;
 }
+
+#[no_mangle]
+pub extern "C" fn smashline_whitelist_kirby_copy_article(
+    fighter_id: i32,
+    article_id: i32
+) {
+    let mut copy_whitelist = crate::cloning::weapons::KIRBY_COPY_ARTICLE_WHITELIST.write();
+    if let Some(whitelist) = copy_whitelist.get_mut(&fighter_id) {
+        if whitelist.contains(&article_id) {
+            println!("Copy Whitelist already contains fighter {:#x} article {:#x}!", fighter_id, article_id);
+        }
+        else {
+            whitelist.push(article_id);
+        }
+    }
+    else {
+        copy_whitelist.insert(fighter_id, vec![article_id]);
+    }
+}


### PR DESCRIPTION
Addresses an issue with the previous release that caused Kirby to crash the game upon copying specific fighters and load specific articles.

# Changelog

- Adds `smashline::whitelist_kirby_copy_article`.
  - Usage: `smashline::whitelist_kirby_copy_article(fighter_id, article_id);`
  - Example: `smashline::whitelist_kirby_copy_article(*FIGHTER_KIND_DOLLY, *WEAPON_KIND_DOLLY_BURST);`