### PR TITLE
Costume Stuff

### DIFF
--- a/crates/smashline/src/builder.rs
+++ b/crates/smashline/src/builder.rs
@@ -103,7 +103,7 @@ impl Agent {
     pub fn new(agent: impl AsHash40) -> Self {
         Self {
             kind_hash: agent.as_hash40(),
-            costume: Costume { data: std::ptr::null(), len: 0 },
+            costume: Costume::default(),
             acmd: vec![],
             lines: vec![],
             status: vec![],

--- a/crates/smashline/src/builder.rs
+++ b/crates/smashline/src/builder.rs
@@ -276,7 +276,12 @@ impl Agent {
         }
 
         for line in self.lines.iter() {
-            crate::api::install_line_callback(Some(self.kind_hash), line.line, line.function);
+            crate::api::install_line_callback_costume(
+                Some(self.kind_hash),
+                self.costume,
+                line.line,
+                line.function
+            );
         }
 
         for event in self.events.iter() {

--- a/crates/smashline/src/builder.rs
+++ b/crates/smashline/src/builder.rs
@@ -103,7 +103,7 @@ impl Agent {
     pub fn new(agent: impl AsHash40) -> Self {
         Self {
             kind_hash: agent.as_hash40(),
-            costume: Costume { min: -1, max: -1 },
+            costume: Costume { data: std::ptr::null(), len: 0 },
             acmd: vec![],
             lines: vec![],
             status: vec![],
@@ -111,9 +111,8 @@ impl Agent {
         }
     }
 
-    pub fn set_costume(&mut self, costume: (i32, i32)) -> &mut Self {
-        self.costume.min = costume.0;
-        self.costume.max = costume.1;
+    pub fn set_costume(&mut self, costumes: Vec<usize>) -> &mut Self {
+        self.costume = Costume::from_vec(costumes);
         self
     }
 

--- a/crates/smashline/src/builder.rs
+++ b/crates/smashline/src/builder.rs
@@ -284,8 +284,9 @@ impl Agent {
         }
 
         for event in self.events.iter() {
-            crate::api::install_state_callback(
+            crate::api::install_state_callback_costume(
                 Some(self.kind_hash),
+                self.costume,
                 event.event,
                 event.function as *const (),
             );

--- a/crates/smashline/src/lib.rs
+++ b/crates/smashline/src/lib.rs
@@ -48,6 +48,13 @@ impl std::fmt::Display for Priority {
 }
 
 #[repr(C)]
+#[derive(Copy, Clone, PartialEq, PartialOrd)]
+pub struct Costume {
+    pub min: i32,
+    pub max: i32,
+}
+
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub enum Acmd {
     Game,
@@ -299,12 +306,29 @@ decl_imports! {
 
     fn smashline_get_action_registry() -> &'static acmd_engine::action::ActionRegistry;
 
+    fn smashline_install_acmd_script_costume(
+        agent: Hash40,
+        costume: Costume,
+        script: Hash40,
+        category: Acmd,
+        priority: Priority,
+        function: unsafe extern "C" fn(&mut L2CAgentBase)
+    );
+
     fn smashline_install_acmd_script(
         agent: Hash40,
         script: Hash40,
         category: Acmd,
         priority: Priority,
         function: unsafe extern "C" fn(&mut L2CAgentBase)
+    );
+
+    fn smashline_install_status_script_costume(
+        agent: Option<NonZeroU64>,
+        costume: Costume,
+        status: i32,
+        line: StatusLine,
+        function: *const ()
     );
 
     fn smashline_install_status_script(
@@ -443,6 +467,17 @@ pub mod api {
         smashline_get_action_registry().register::<A>();
     }
 
+    pub fn install_status_script_costume(
+        agent: Option<Hash40>,
+        costume: Costume,
+        line: StatusLine,
+        kind: i32,
+        function: *const (),
+    ) {
+        let agent = agent.and_then(|x| NonZeroU64::new(extract_hash(x)));
+        smashline_install_status_script_costume(agent, costume, kind, line, function);
+    }
+
     pub fn install_status_script(
         agent: Option<Hash40>,
         line: StatusLine,
@@ -456,6 +491,17 @@ pub mod api {
     pub fn install_line_callback(agent: Option<Hash40>, line: StatusLine, function: *const ()) {
         let agent = agent.and_then(|x| NonZeroU64::new(extract_hash(x)));
         smashline_install_line_callback(agent, line, function);
+    }
+
+    pub fn install_acmd_script_costume(
+        agent: Hash40,
+        costume: Costume,
+        script: Hash40,
+        category: Acmd,
+        priority: Priority,
+        function: unsafe extern "C" fn(&mut L2CAgentBase),
+    ) {
+        smashline_install_acmd_script_costume(agent, costume, script, category, priority, function);
     }
 
     pub fn install_acmd_script(

--- a/crates/smashline/src/lib.rs
+++ b/crates/smashline/src/lib.rs
@@ -338,6 +338,13 @@ decl_imports! {
         function: *const ()
     );
 
+    fn smashline_install_line_callback_costume(
+        agent: Option<NonZeroU64>,
+        costume: Costume,
+        line: StatusLine,
+        callback: *const ()
+    );
+
     fn smashline_install_line_callback(
         agent: Option<NonZeroU64>,
         line: StatusLine,
@@ -488,7 +495,21 @@ pub mod api {
         smashline_install_status_script(agent, kind, line, function);
     }
 
-    pub fn install_line_callback(agent: Option<Hash40>, line: StatusLine, function: *const ()) {
+    pub fn install_line_callback_costume(
+        agent: Option<Hash40>,
+        costume: Costume,
+        line: StatusLine,
+        function: *const (),
+    ) {
+        let agent = agent.and_then(|x| NonZeroU64::new(extract_hash(x)));
+        smashline_install_line_callback_costume(agent, costume, line, function);
+    }
+
+    pub fn install_line_callback(
+        agent: Option<Hash40>,
+        line: StatusLine,
+        function: *const (),
+    ) {
         let agent = agent.and_then(|x| NonZeroU64::new(extract_hash(x)));
         smashline_install_line_callback(agent, line, function);
     }

--- a/crates/smashline/src/lib.rs
+++ b/crates/smashline/src/lib.rs
@@ -47,14 +47,17 @@ impl std::fmt::Display for Priority {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct AgentEntry {
     pub hash: u64,
-    pub costume_data: *const usize
+    pub costume_data: Vec<usize>,
 }
 impl AgentEntry {
-    pub fn new(hash: u64, costume_data: *const usize) -> Self {
-        Self { hash, costume_data }
+    pub fn new(agent: u64, costume: Costume) -> Self {
+        Self { 
+            hash: agent, 
+            costume_data: costume.as_slice().to_vec()
+        }
     }
 }
 

--- a/crates/smashline/src/lib.rs
+++ b/crates/smashline/src/lib.rs
@@ -50,8 +50,27 @@ impl std::fmt::Display for Priority {
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
 pub struct Costume {
-    pub min: i32,
-    pub max: i32,
+    pub data: *const usize,
+    pub len: usize,
+}
+
+impl Costume {
+    pub fn from_vec(vec: Vec<usize>) -> Self {
+        let len = vec.len();
+        let data = vec.as_ptr();
+        std::mem::forget(vec);
+        Costume { data, len }
+    }
+
+    pub fn as_slice(self) -> &'static [usize] {
+        unsafe {
+            if self.data.is_null() || self.len == 0 {
+                return &[];
+            }
+
+            std::slice::from_raw_parts(self.data, self.len)
+        }
+    }
 }
 
 #[repr(C)]

--- a/crates/smashline/src/lib.rs
+++ b/crates/smashline/src/lib.rs
@@ -400,6 +400,13 @@ decl_imports! {
         original: &'static locks::RwLock<*const ()>
     );
 
+    fn smashline_install_state_callback_costume(
+        agent: Option<NonZeroU64>,
+        costume: Costume,
+        event: ObjectEvent,
+        callback: *const ()
+    );
+
     fn smashline_install_state_callback(
         agent: Option<NonZeroU64>,
         event: ObjectEvent,
@@ -589,6 +596,15 @@ pub mod api {
                 std::mem::transmute(original),
             );
         }
+    }
+
+    pub fn install_state_callback_costume(agent: Option<Hash40>, costume: Costume, event: ObjectEvent, function: *const ()) {
+        smashline_install_state_callback_costume(
+            agent.and_then(|x| NonZeroU64::new(extract_hash(x))),
+            costume,
+            event,
+            function,
+        );
     }
 
     pub fn install_state_callback(agent: Option<Hash40>, event: ObjectEvent, function: *const ()) {

--- a/crates/smashline/src/lib.rs
+++ b/crates/smashline/src/lib.rs
@@ -47,11 +47,27 @@ impl std::fmt::Display for Priority {
     }
 }
 
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct AgentEntry {
+    pub hash: u64,
+    pub costume_data: *const usize
+}
+impl AgentEntry {
+    pub fn new(hash: u64, costume_data: *const usize) -> Self {
+        Self { hash, costume_data }
+    }
+}
+
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub struct Costume {
     pub data: *const usize,
     pub len: usize,
+}
+impl Default for Costume {
+    fn default() -> Self {
+        Costume { data: std::ptr::null(), len: 0 }
+    }
 }
 
 impl Costume {

--- a/crates/vtables/src/lib.rs
+++ b/crates/vtables/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(pointer_is_aligned)]
 #![feature(strict_provenance)]
 #![feature(exposed_provenance)]
 use std::{

--- a/src/api.rs
+++ b/src/api.rs
@@ -95,14 +95,14 @@ pub extern "C" fn smashline_install_acmd_script_costume(
     if unsafe { crate::runtime_reload::LOADING_DEVELOPMENT_SCRIPTS } {
         crate::create_agent::ACMD_SCRIPTS_DEV
             .write()
-            .entry(AgentEntry::new(agent.0, costume.data))
+            .entry(AgentEntry::new(agent.0, costume))
             .or_default()
             .set_script(script, category, AcmdScript { function, priority, costume });
         return;
     }
     crate::create_agent::ACMD_SCRIPTS
         .write()
-        .entry(AgentEntry::new(agent.0, costume.data))
+        .entry(AgentEntry::new(agent.0, costume))
         .or_default()
         .set_script(script, category, AcmdScript { function, priority, costume });
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,7 +6,7 @@ use std::{
 use acmd_engine::action::ActionRegistry;
 use rtld::Section;
 use smashline::{
-    Acmd, AcmdFunction, Costume, Hash40, L2CAgentBase, ObjectEvent, Priority, StatusLine, StringFFI,
+    Acmd, AcmdFunction, AgentEntry, Costume, Hash40, L2CAgentBase, ObjectEvent, Priority, StatusLine, StringFFI,
 };
 
 use crate::{
@@ -95,14 +95,14 @@ pub extern "C" fn smashline_install_acmd_script_costume(
     if unsafe { crate::runtime_reload::LOADING_DEVELOPMENT_SCRIPTS } {
         crate::create_agent::ACMD_SCRIPTS_DEV
             .write()
-            .entry(agent)
+            .entry(AgentEntry::new(agent.0, costume.data))
             .or_default()
             .set_script(script, category, AcmdScript { function, priority, costume });
         return;
     }
     crate::create_agent::ACMD_SCRIPTS
         .write()
-        .entry(agent)
+        .entry(AgentEntry::new(agent.0, costume.data))
         .or_default()
         .set_script(script, category, AcmdScript { function, priority, costume });
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -31,18 +31,17 @@ fn mark_costume(
             .or_default();
 
         for c in &mut *costumes {
-            if costume.min < c.max && costume.max > c.min {
-                let name = {
-                    let mut ret = agent.to_label();
+            if costume == *c {
+                continue;
+            }
 
-                    for n in LOWERCASE_FIGHTER_NAMES .iter() {
-                        if Hash40::new(n) == agent {
-                            ret = n.to_string();
-                        }
-                    }
-
-                    ret
-                };
+            if costume.min <= c.max && costume.max >= c.min {
+                let name = LOWERCASE_FIGHTER_NAMES
+                    .iter()
+                    .chain(LOWERCASE_WEAPON_NAMES.iter())
+                    .find(|&n| Hash40::new(n) == agent)
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| agent.to_label());
 
                 // It is possible for 2 fighters of the same kind and similar/overlapping costumes
                 // to work using some sort of identifer on top of the costume, such as a unique

--- a/src/api.rs
+++ b/src/api.rs
@@ -115,7 +115,7 @@ pub extern "C" fn smashline_install_acmd_script(
     priority: Priority,
     function: unsafe extern "C" fn(&mut L2CAgentBase),
 ) {
-    smashline_install_acmd_script_costume(agent, Costume { data: std::ptr::null(), len: 0 }, script, category, priority, function);
+    smashline_install_acmd_script_costume(agent, Costume::default(), script, category, priority, function);
 }
 
 #[no_mangle]
@@ -162,7 +162,7 @@ pub extern "C" fn smashline_install_status_script(
     line: StatusLine,
     function: *const (),
 ) {
-    smashline_install_status_script_costume(agent, Costume { data: std::ptr::null(), len: 0 }, status, line, function);
+    smashline_install_status_script_costume(agent, Costume::default(), status, line, function);
 }
 
 #[no_mangle]
@@ -192,7 +192,7 @@ pub extern "C" fn smashline_install_line_callback(
     line: StatusLine,
     function: *const (),
 ) {
-    smashline_install_line_callback_costume(agent, Costume { data: std::ptr::null(), len: 0 }, line, function);
+    smashline_install_line_callback_costume(agent, Costume::default(), line, function);
 }
 
 #[no_mangle]

--- a/src/api.rs
+++ b/src/api.rs
@@ -185,6 +185,11 @@ pub extern "C" fn smashline_install_line_callback_costume(
 ) {
     let agent = agent.map(|value| Hash40(value.get()));
 
+    if agent != Some(Hash40::new("fighter"))
+    && agent != Some(Hash40::new("weapon")) {
+        mark_costume(agent.unwrap(), costume);
+    }
+
     crate::callbacks::CALLBACKS.write().push(StatusCallback {
         hash: agent,
         function: StatusCallbackFunction::new(line, function),

--- a/src/api.rs
+++ b/src/api.rs
@@ -232,18 +232,36 @@ pub extern "C" fn smashline_get_original_status(
 }
 
 #[no_mangle]
+pub extern "C" fn smashline_install_state_callback_costume(
+    agent: Option<NonZeroU64>,
+    costume: Costume,
+    event: ObjectEvent,
+    function: StateCallbackFunction,
+) {
+    let agent = agent.map(|value| Hash40(value.get()));
+
+    if agent != Some(Hash40::new("fighter"))
+    && agent != Some(Hash40::new("weapon")) {
+        mark_costume(agent.unwrap(), costume);
+    }
+
+    crate::state_callback::STATE_CALLBACKS
+        .write()
+        .push(StateCallback {
+            agent,
+            event,
+            function,
+            costume,
+        });
+}
+
+#[no_mangle]
 pub extern "C" fn smashline_install_state_callback(
     agent: Option<NonZeroU64>,
     event: ObjectEvent,
     function: StateCallbackFunction,
 ) {
-    crate::state_callback::STATE_CALLBACKS
-        .write()
-        .push(StateCallback {
-            agent: agent.map(|x| Hash40(x.get())),
-            event,
-            function,
-        });
+    smashline_install_state_callback_costume(agent, Costume::default(), event, function);
 }
 
 #[no_mangle]

--- a/src/api.rs
+++ b/src/api.rs
@@ -32,7 +32,7 @@ fn mark_costume(
 
         for c in &mut *costumes {
             if costume == *c {
-                continue;
+                return;
             }
 
             if costume.min <= c.max && costume.max >= c.min {

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -1,7 +1,7 @@
 use locks::RwLock;
 use skyline::hooks::InlineCtx;
 use smash::lib::L2CValue;
-use smashline::{Hash40, L2CFighterBase, StatusLine, Variadic};
+use smashline::{Costume, Hash40, L2CFighterBase, StatusLine, Variadic};
 
 pub type Callback = extern "C" fn(&mut L2CFighterBase);
 pub type Callback1 = extern "C" fn(&mut L2CFighterBase, &mut L2CValue);
@@ -81,6 +81,7 @@ impl StatusCallbackFunction {
 pub struct StatusCallback {
     pub hash: Option<Hash40>,
     pub function: StatusCallbackFunction,
+    pub costume: Costume,
 }
 
 pub static CALLBACKS: RwLock<Vec<StatusCallback>> = RwLock::new(Vec::new());

--- a/src/cloning/fighters.rs
+++ b/src/cloning/fighters.rs
@@ -38,7 +38,7 @@ pub struct NewFighter {
     pub hash: Hash40,
 }
 
-pub(super) static CURRENT_PLAYER_ID: AtomicUsize = AtomicUsize::new(usize::MAX);
+pub static CURRENT_PLAYER_ID: AtomicUsize = AtomicUsize::new(usize::MAX);
 
 #[skyline::from_offset(0x3262130)]
 fn lookup_fighter_kind_from_ui_hash(database: u64, hash: u64) -> i32;

--- a/src/create_agent.rs
+++ b/src/create_agent.rs
@@ -166,14 +166,14 @@ impl StatusScriptFunction {
 pub struct StatusScript {
     pub id: i32,
     pub function: StatusScriptFunction,
-    pub costume: Costume
+    pub costume: Costume,
 }
 
 #[derive(Copy, Clone)]
 pub struct AcmdScript {
     pub function: unsafe extern "C" fn(&mut L2CAgentBase),
     pub priority: Priority,
-    pub costume: Costume
+    pub costume: Costume,
 }
 
 type AcmdScriptSet = HashMap<Hash40, AcmdScript>;
@@ -254,13 +254,12 @@ fn install_script(
     if let Some(scripts) = acmd_scripts.get(&agent_hash) {
         for (hash, script) in scripts.get_scripts(acmd) {
             let c = script.costume;
-            const NO_COSTUME: Costume = Costume { min: -1, max: -1 };
 
-            if has_costume && !(c.min..=c.max).contains(&costume) {
+            if has_costume && !c.as_slice().contains(&(costume as usize)) {
                 continue;
             }
 
-            if !has_costume && c != NO_COSTUME {
+            if !has_costume && !c.data.is_null() {
                 continue;
             }
 
@@ -744,13 +743,12 @@ fn install_status_scripts(
 
     for status in list.iter() {
         let c = status.costume;
-        const NO_COSTUME: Costume = Costume { min: -1, max: -1 };
 
-        if has_costume && !(c.min..=c.max).contains(&costume) {
+        if has_costume && !c.as_slice().contains(&(costume as usize)) {
             continue;
         }
 
-        if !has_costume && c != NO_COSTUME {
+        if !has_costume && !c.data.is_null() {
             continue;
         }
 
@@ -871,13 +869,12 @@ extern "C" fn set_status_scripts(agent: &mut L2CFighterWrapper) {
     for callback in callbacks.iter() {
         if callback.hash == Some(hash) {
             let c = callback.costume;
-            const NO_COSTUME: Costume = Costume { min: -1, max: -1 };
 
-            if has_costume && !(c.min..=c.max).contains(&costume) {
+            if has_costume && !c.as_slice().contains(&(costume as usize)) {
                 continue;
             }
 
-            if !has_costume && c != NO_COSTUME {
+            if !has_costume && !c.data.is_null() {
                 continue;
             }
 

--- a/src/create_agent.rs
+++ b/src/create_agent.rs
@@ -261,13 +261,13 @@ fn install_script(
     let acmd_scripts = acmd_scripts.read();
     if let Some(scripts) = acmd_scripts.get(&entry) {
         for (hash, script) in scripts.get_scripts(acmd) {
-            let c = script.costume;
+            let c = script.costume.as_slice();
 
-            if has_costume && !c.as_slice().contains(&(costume as usize)) {
+            if has_costume && !c.contains(&(costume as usize)) {
                 continue;
             }
 
-            if !has_costume && !c.data.is_null() {
+            if !has_costume && !c.is_empty() {
                 continue;
             }
 
@@ -750,13 +750,13 @@ fn install_status_scripts(
     let mut max_new = old_total;
 
     for status in list.iter() {
-        let c = status.costume;
+        let c = status.costume.as_slice();
 
-        if has_costume && !c.as_slice().contains(&(costume as usize)) {
+        if has_costume && !c.contains(&(costume as usize)) {
             continue;
         }
 
-        if !has_costume && !c.data.is_null() {
+        if !has_costume && !c.is_empty() {
             continue;
         }
 
@@ -876,13 +876,13 @@ extern "C" fn set_status_scripts(agent: &mut L2CFighterWrapper) {
 
     for callback in callbacks.iter() {
         if callback.hash == Some(hash) {
-            let c = callback.costume;
+            let c = callback.costume.as_slice();
 
-            if has_costume && !c.as_slice().contains(&(costume as usize)) {
+            if has_costume && !c.contains(&(costume as usize)) {
                 continue;
             }
 
-            if !has_costume && !c.data.is_null() {
+            if !has_costume && !c.is_empty() {
                 continue;
             }
 

--- a/src/create_agent.rs
+++ b/src/create_agent.rs
@@ -251,7 +251,7 @@ fn install_script(
     user_scripts: &mut HashMap<Hash40, UserScript>,
     is_weapon: bool,
 ) {
-    let costume = crate::utils::get_agent_costume(agent.battle_object as *const BattleObject, is_weapon);
+    let costume = crate::utils::get_agent_costume(agent.battle_object as *const BattleObject, is_weapon).unwrap_or(0);
     let has_costume = crate::utils::has_costume(agent_hash, costume);
     let entry = AgentEntry::new(
         agent_hash.0,
@@ -744,7 +744,7 @@ fn install_status_scripts(
     let data = vtables::vtable_custom_data::<_, L2CFighterWrapper>(agent.deref()).unwrap();
     let is_weapon = data.is_weapon;
 
-    let costume = crate::utils::get_agent_costume(agent.0.battle_object as *const BattleObject, is_weapon);
+    let costume = crate::utils::get_agent_costume(agent.0.battle_object as *const BattleObject, is_weapon).unwrap_or(0);
     let has_costume = crate::utils::has_costume(data.hash, costume);
 
     let mut max_new = old_total;
@@ -868,7 +868,7 @@ extern "C" fn set_status_scripts(agent: &mut L2CFighterWrapper) {
         }
     }
 
-    let costume = crate::utils::get_agent_costume(agent.0.battle_object as *const BattleObject, is_weapon);
+    let costume = crate::utils::get_agent_costume(agent.0.battle_object as *const BattleObject, is_weapon).unwrap_or(0);
     let has_costume = crate::utils::has_costume(hash, costume);
 
     let callbacks = CALLBACKS.read();

--- a/src/create_agent.rs
+++ b/src/create_agent.rs
@@ -254,8 +254,8 @@ fn install_script(
     let costume = crate::utils::get_agent_costume(agent.battle_object as *const BattleObject, is_weapon);
     let has_costume = crate::utils::has_costume(agent_hash, costume);
     let entry = AgentEntry::new(
-        agent_hash.0, 
-        crate::utils::get_costume_data(agent_hash, costume).data
+        agent_hash.0,
+        crate::utils::get_costume_data(agent_hash, costume)
     );
 
     let acmd_scripts = acmd_scripts.read();

--- a/src/create_agent.rs
+++ b/src/create_agent.rs
@@ -237,6 +237,26 @@ fn check_installed_script(acmd_map: &mut AcmdScriptSet, name: Hash40, category: 
     }
 }
 
+fn install_script(
+    acmd_scripts: &RwLock<BTreeMap<Hash40, AcmdScripts>>,
+    agent_hash: Hash40,
+    acmd: Acmd,
+    agent: &mut L2CAgentBase,
+    user_scripts: &mut HashMap<Hash40, UserScript>,
+) {
+    let acmd_scripts = acmd_scripts.read();
+    if let Some(scripts) = acmd_scripts.get(&agent_hash) {
+        for (hash, script) in scripts.get_scripts(acmd) {
+            agent.sv_set_function_hash(
+                unsafe { std::mem::transmute(unreachable_smashline_script as *const ()) },
+                *hash,
+            );
+
+            user_scripts.insert(*hash, UserScript::Function(script.function));
+        }
+    }
+}
+
 pub static ACMD_SCRIPTS: RwLock<BTreeMap<Hash40, AcmdScripts>> = RwLock::new(BTreeMap::new());
 pub static ACMD_SCRIPTS_DEV: RwLock<BTreeMap<Hash40, AcmdScripts>> = RwLock::new(BTreeMap::new());
 pub static STATUS_SCRIPTS: RwLock<BTreeMap<Hash40, Vec<StatusScript>>> =
@@ -498,29 +518,8 @@ fn create_agent_hook(
                 );
             }
 
-            let acmd_scripts = ACMD_SCRIPTS.read();
-            if let Some(scripts) = acmd_scripts.get(&hash) {
-                for (hash, script) in scripts.get_scripts(acmd) {
-                    agent.sv_set_function_hash(
-                        unsafe { std::mem::transmute(unreachable_smashline_script as *const ()) },
-                        *hash,
-                    );
-
-                    user_scripts.insert(*hash, UserScript::Function(script.function));
-                }
-            }
-
-            let acmd_scripts_dev = ACMD_SCRIPTS_DEV.read();
-            if let Some(scripts) = acmd_scripts_dev.get(&hash) {
-                for (hash, script) in scripts.get_scripts(acmd) {
-                    agent.sv_set_function_hash(
-                        unsafe { std::mem::transmute(unreachable_smashline_script as *const ()) },
-                        *hash,
-                    );
-
-                    user_scripts.insert(*hash, UserScript::Function(script.function));
-                }
-            }
+            install_script(&ACMD_SCRIPTS, hash, acmd, agent, &mut user_scripts);
+            install_script(&ACMD_SCRIPTS_DEV, hash, acmd, agent, &mut user_scripts);
 
             let agent: &'static mut L2CAgentBase = unsafe {
                 let wrapper: &'static mut L2CAnimcmdWrapper = std::mem::transmute(agent);
@@ -609,29 +608,8 @@ fn create_agent_hook(
                 );
             }
 
-            let acmd_scripts = ACMD_SCRIPTS.read();
-            if let Some(scripts) = acmd_scripts.get(&hash) {
-                for (hash, script) in scripts.get_scripts(acmd) {
-                    agent.sv_set_function_hash(
-                        unsafe { std::mem::transmute(unreachable_smashline_script as *const ()) },
-                        *hash,
-                    );
-
-                    user_scripts.insert(*hash, UserScript::Function(script.function));
-                }
-            }
-
-            let acmd_scripts_dev = ACMD_SCRIPTS_DEV.read();
-            if let Some(scripts) = acmd_scripts_dev.get(&hash) {
-                for (hash, script) in scripts.get_scripts(acmd) {
-                    agent.sv_set_function_hash(
-                        unsafe { std::mem::transmute(unreachable_smashline_script as *const ()) },
-                        *hash,
-                    );
-
-                    user_scripts.insert(*hash, UserScript::Function(script.function));
-                }
-            }
+            install_script(&ACMD_SCRIPTS, hash, acmd, agent, &mut user_scripts);
+            install_script(&ACMD_SCRIPTS_DEV, hash, acmd, agent, &mut user_scripts);
 
             let agent: &'static mut L2CAgentBase = unsafe {
                 let wrapper: &'static mut L2CAnimcmdWrapper = std::mem::transmute(agent);

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -34,7 +34,7 @@ pub fn get_scripts(fighter_name: &str, weapon_name: Option<&str>) -> Vec<LoadedS
     let read_dir = match std::fs::read_dir(&path) {
         Ok(read_dir) => read_dir,
         Err(e) => {
-            println!("Failed to get scripts: {e}");
+            // println!("Failed to get scripts: {e}");
             return vec![];
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,8 +94,10 @@
 //! might display an interaction with sloped ground or how rumble is applied will happen in these
 //! scripts.
 //!
-#![feature(new_uninit)]
+#![allow(unused)]
 #![allow(non_snake_case)]
+#![allow(static_mut_refs)]
+#![allow(elided_named_lifetimes)]
 
 mod cloning;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -47,11 +47,11 @@ pub fn get_costume_from_entry_id(entry_id: i32) -> Option<i32> {
         let some_struct = *((some_vec + index + 0xe8) as *const u64);
 
         const COSTUME_OFFSET: u64 = 100;
-        let ptr = ((some_struct + COSTUME_OFFSET) as *const u64);
+        let ptr = (some_struct + COSTUME_OFFSET) as *const i32;
         if ptr as u64 == 0x64 { // entry articles
             None
         } else {
-            Some(*(ptr as *const i32))
+            Some(*ptr)
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::Ordering;
 
 use smash::app::BattleObject;
-use smashline::Hash40;
+use smashline::{Costume, Hash40};
 
 use crate::{
     cloning::fighters::CURRENT_PLAYER_ID,
@@ -70,6 +70,17 @@ pub fn has_costume(hash: Hash40, costume: i32) -> bool {
             costume_vec.iter().any(|c| {
                 c.as_slice().contains(&(costume as usize))
             })
+        })
+}
+
+pub fn get_costume_data(hash: Hash40, costume: i32) -> Costume {
+    let def = Costume::default();
+    COSTUMES
+        .read()
+        .get(&hash).map_or(def, |costume_vec| {
+            costume_vec.iter().find(|c| {
+                c.as_slice().contains(&(costume as usize))
+            }).copied().unwrap_or(def)
         })
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -67,8 +67,10 @@ pub fn has_costume(hash: Hash40, costume: i32) -> bool {
     COSTUMES
         .read()
         .get(&hash).map_or(false, |costume_vec| {
-        costume_vec.iter().any(|c| (c.min..=c.max).contains(&costume))
-    })
+            costume_vec.iter().any(|c| {
+                c.as_slice().contains(&(costume as usize))
+            })
+        })
 }
 
 fn dynamic_module_manager() -> *mut u64 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,6 +32,20 @@ pub fn get_weapon_code_dependency(id: i32) -> Option<i32> {
     try_get_new_agent(&agents, id, current_owner).and_then(|x| x.use_original_code.then_some(x.old_owner_id))
 }
 
+pub fn get_costume(entry_id: i32) -> i32 {
+    unsafe {
+        const VEC_OFFSET: u64 = 0x5324680;
+        let some_vec = skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64 + VEC_OFFSET;
+        let some_vec = *(some_vec as *const u64);
+
+        let index = entry_id as u64 * 8;
+        let some_struct = *((some_vec + index + 0xe8) as *const u64);
+
+        const COSTUME_OFFSET: u64 = 100;
+        *((some_struct + COSTUME_OFFSET) as *const u64) as i32
+    }
+}
+
 fn dynamic_module_manager() -> *mut u64 {
     let text = unsafe { skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as *mut u8 };
     unsafe { **text.add(0x5327cd0).cast::<*mut *mut u64>() }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,13 @@
 use std::sync::atomic::Ordering;
 
+use smash::app::BattleObject;
 use smashline::Hash40;
 
-use crate::{cloning::weapons::{try_get_new_agent, CURRENT_OWNER_KIND, NEW_AGENTS}, create_agent::{LOWERCASE_WEAPON_NAMES, LOWERCASE_WEAPON_OWNER_NAMES, LOWERCASE_FIGHTER_NAMES}};
+use crate::{
+    cloning::fighters::CURRENT_PLAYER_ID,
+    cloning::weapons::{try_get_new_agent, CURRENT_OWNER_KIND, NEW_AGENTS},
+    create_agent::{COSTUMES, LOWERCASE_WEAPON_NAMES, LOWERCASE_WEAPON_OWNER_NAMES, LOWERCASE_FIGHTER_NAMES}
+};
 
 pub fn get_weapon_name(id: i32) -> Option<String> {
     let current_owner = CURRENT_OWNER_KIND.load(Ordering::Relaxed);
@@ -32,7 +37,7 @@ pub fn get_weapon_code_dependency(id: i32) -> Option<i32> {
     try_get_new_agent(&agents, id, current_owner).and_then(|x| x.use_original_code.then_some(x.old_owner_id))
 }
 
-pub fn get_costume(entry_id: i32) -> i32 {
+pub fn get_costume_from_entry_id(entry_id: i32) -> i32 {
     unsafe {
         const VEC_OFFSET: u64 = 0x5324680;
         let some_vec = skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64 + VEC_OFFSET;
@@ -44,6 +49,26 @@ pub fn get_costume(entry_id: i32) -> i32 {
         const COSTUME_OFFSET: u64 = 100;
         *((some_struct + COSTUME_OFFSET) as *const u64) as i32
     }
+}
+
+pub fn get_agent_costume(battle_object: *const BattleObject, is_weapon: bool) -> i32 {
+    unsafe {
+        let entry_id = if is_weapon {
+            CURRENT_PLAYER_ID.load(Ordering::Relaxed) as i32
+        } else {
+            (*battle_object).entry_id
+        };
+
+        crate::utils::get_costume_from_entry_id(entry_id)
+    }
+}
+
+pub fn has_costume(hash: Hash40, costume: i32) -> bool {
+    COSTUMES
+        .read()
+        .get(&hash).map_or(false, |costume_vec| {
+        costume_vec.iter().any(|c| (c.min..=c.max).contains(&costume))
+    })
 }
 
 fn dynamic_module_manager() -> *mut u64 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -37,7 +37,7 @@ pub fn get_weapon_code_dependency(id: i32) -> Option<i32> {
     try_get_new_agent(&agents, id, current_owner).and_then(|x| x.use_original_code.then_some(x.old_owner_id))
 }
 
-pub fn get_costume_from_entry_id(entry_id: i32) -> i32 {
+pub fn get_costume_from_entry_id(entry_id: i32) -> Option<i32> {
     unsafe {
         const VEC_OFFSET: u64 = 0x5324680;
         let some_vec = skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64 + VEC_OFFSET;
@@ -47,11 +47,16 @@ pub fn get_costume_from_entry_id(entry_id: i32) -> i32 {
         let some_struct = *((some_vec + index + 0xe8) as *const u64);
 
         const COSTUME_OFFSET: u64 = 100;
-        *((some_struct + COSTUME_OFFSET) as *const u64) as i32
+        let ptr = ((some_struct + COSTUME_OFFSET) as *const u64);
+        if ptr as u64 == 0x64 { // entry articles
+            None
+        } else {
+            Some(*(ptr as *const i32))
+        }
     }
 }
 
-pub fn get_agent_costume(battle_object: *const BattleObject, is_weapon: bool) -> i32 {
+pub fn get_agent_costume(battle_object: *const BattleObject, is_weapon: bool) -> Option<i32> {
     unsafe {
         let entry_id = if is_weapon {
             CURRENT_PLAYER_ID.load(Ordering::Relaxed) as i32


### PR DESCRIPTION
ACMD's, Status Scripts, and OPFF(`on_line`) can now be install on a specific costume.

These changes will not affect plugins built before this update and will still work.
# Changelog

## Adds `.set_costume` to `Agent`
Usage: `.set_costume((min_costume, max_costume))`
Example:
```rust
Agent::new("mario")
    .set_costume([0, 1, 2, 3, 4, 5, 6, 7].to_vec())
    .acmd(...)
    .status(...)
    .install();
```
## Exports
Exports 3 new functions that are to be used with the newly added `Costume`
```rust
smashline_install_acmd_script_costume(
    agent: Hash40,
    costume: Option<Costume>,
    script: Hash40,
    category: Acmd,
    priority: Priority,
    function: unsafe extern "C" fn(&mut L2CAgentBase),
)
smashline_install_status_script_costume(
    agent: Option<NonZeroU64>,
    costume: Option<Costume>,
    status: i32,
    line: StatusLine,
    function: *const (),
)
smashline_install_line_callback_costume(
    agent: Option<NonZeroU64>,
    costume: Option<Costume>,
    line: StatusLine,
    function: *const (),
)
```