### PR TITLE
Fixes state callbacks on weapons

### DIFF
--- a/src/create_agent.rs
+++ b/src/create_agent.rs
@@ -249,9 +249,8 @@ fn install_script(
     acmd: Acmd,
     agent: &mut L2CAgentBase,
     user_scripts: &mut HashMap<Hash40, UserScript>,
-    is_weapon: bool,
 ) {
-    let costume = crate::utils::get_agent_costume(agent.battle_object as *const BattleObject, is_weapon).unwrap_or(0);
+    let costume = crate::utils::get_agent_costume(agent.battle_object as *const BattleObject).unwrap_or(0);
     let has_costume = crate::utils::has_costume(agent_hash, costume);
     let entry = AgentEntry::new(
         agent_hash.0,
@@ -544,8 +543,8 @@ fn create_agent_hook(
                 );
             }
 
-            install_script(&ACMD_SCRIPTS, hash, acmd, agent, &mut user_scripts, false);
-            install_script(&ACMD_SCRIPTS_DEV, hash, acmd, agent, &mut user_scripts, false);
+            install_script(&ACMD_SCRIPTS, hash, acmd, agent, &mut user_scripts);
+            install_script(&ACMD_SCRIPTS_DEV, hash, acmd, agent, &mut user_scripts);
 
             let agent: &'static mut L2CAgentBase = unsafe {
                 let wrapper: &'static mut L2CAnimcmdWrapper = std::mem::transmute(agent);
@@ -634,8 +633,8 @@ fn create_agent_hook(
                 );
             }
 
-            install_script(&ACMD_SCRIPTS, hash, acmd, agent, &mut user_scripts, true);
-            install_script(&ACMD_SCRIPTS_DEV, hash, acmd, agent, &mut user_scripts, true);
+            install_script(&ACMD_SCRIPTS, hash, acmd, agent, &mut user_scripts);
+            install_script(&ACMD_SCRIPTS_DEV, hash, acmd, agent, &mut user_scripts);
 
             let agent: &'static mut L2CAgentBase = unsafe {
                 let wrapper: &'static mut L2CAnimcmdWrapper = std::mem::transmute(agent);
@@ -742,9 +741,7 @@ fn install_status_scripts(
     agent: &mut L2CFighterWrapper,
 ) -> i32 {
     let data = vtables::vtable_custom_data::<_, L2CFighterWrapper>(agent.deref()).unwrap();
-    let is_weapon = data.is_weapon;
-
-    let costume = crate::utils::get_agent_costume(agent.0.battle_object as *const BattleObject, is_weapon).unwrap_or(0);
+    let costume = crate::utils::get_agent_costume(agent.0.battle_object as *const BattleObject).unwrap_or(0);
     let has_costume = crate::utils::has_costume(data.hash, costume);
 
     let mut max_new = old_total;
@@ -868,7 +865,7 @@ extern "C" fn set_status_scripts(agent: &mut L2CFighterWrapper) {
         }
     }
 
-    let costume = crate::utils::get_agent_costume(agent.0.battle_object as *const BattleObject, is_weapon).unwrap_or(0);
+    let costume = crate::utils::get_agent_costume(agent.0.battle_object as *const BattleObject).unwrap_or(0);
     let has_costume = crate::utils::has_costume(hash, costume);
 
     let callbacks = CALLBACKS.read();

--- a/src/state_callback.rs
+++ b/src/state_callback.rs
@@ -21,12 +21,7 @@ fn call_state_callback(agent: &mut L2CFighterBase, event: ObjectEvent) {
     let object: &mut BattleObject = unsafe {std::mem::transmute(agent.battle_object)};
     let category = BattleObjectCategory::from_battle_object_id(object.battle_object_id);
 
-    let is_weapon = match category {
-        Some(BattleObjectCategory::Weapon) => true,
-        _ => false,
-    };
-
-    let costume = crate::utils::get_agent_costume(agent.battle_object as *const BattleObject, is_weapon).unwrap_or(0);
+    let costume = crate::utils::get_agent_costume(agent.battle_object as *const BattleObject).unwrap_or(0);
     let has_costume = crate::utils::has_costume(hash, costume);
 
     for callback in callbacks.iter().filter(|cb| cb.event == event) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,16 +56,9 @@ pub fn get_costume_from_entry_id(entry_id: i32) -> Option<i32> {
     }
 }
 
-pub fn get_agent_costume(battle_object: *const BattleObject, is_weapon: bool) -> Option<i32> {
-    unsafe {
-        let entry_id = if is_weapon {
-            CURRENT_PLAYER_ID.load(Ordering::Relaxed) as i32
-        } else {
-            (*battle_object).entry_id
-        };
-
-        crate::utils::get_costume_from_entry_id(entry_id)
-    }
+pub fn get_agent_costume(battle_object: *const BattleObject) -> Option<i32> {
+    let entry_id = unsafe { (*battle_object).entry_id };
+    crate::utils::get_costume_from_entry_id(entry_id)
 }
 
 pub fn has_costume(hash: Hash40, costume: i32) -> bool {


### PR DESCRIPTION
`CURRENT_PLAYER_ID` returns -1 at any time other than loading a match, which causes `on_start/on_end/on_fini` on weapons to fail to run due to being unable to find costume data. This fixes the issue by just using `battle_object.entry_id` for both fighters and weapons.

Fixes: #55 